### PR TITLE
add `tei:l`, `tei:lg`, and `tei:space` templates

### DIFF
--- a/xslt/editions.xsl
+++ b/xslt/editions.xsl
@@ -244,6 +244,17 @@
             </xsl:otherwise>
         </xsl:choose>     
     </xsl:template>
+    <xsl:template match="tei:space">
+        <xsl:param name="view"/>
+        <xsl:choose>
+            <xsl:when test="$view = 'diplomatic' or $view = 'commentary'">
+                <xsl:value-of select="string-join((for $i in 1 to @quantity return '&#x00A0;'),'')"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:apply-templates/>
+            </xsl:otherwise>
+        </xsl:choose>    
+    </xsl:template>
     <xsl:template match="tei:del">
         <xsl:param name="view"/>
         <xsl:choose>

--- a/xslt/editions.xsl
+++ b/xslt/editions.xsl
@@ -222,6 +222,17 @@
             <br/>
         </xsl:if>
     </xsl:template>
+        <xsl:template match="tei:l">
+        <xsl:param name="view"/>
+        <xsl:choose>
+            <xsl:when test="$view = 'diplomatic' or $view = 'commentary' or $view = 'reading'">
+                <xsl:apply-templates/><br />
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:apply-templates/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
     <xsl:template match="tei:unclear">
         <xsl:param name="view"/>
         <xsl:choose>

--- a/xslt/editions.xsl
+++ b/xslt/editions.xsl
@@ -222,7 +222,18 @@
             <br/>
         </xsl:if>
     </xsl:template>
-        <xsl:template match="tei:l">
+    <xsl:template match="tei:lg">
+        <xsl:param name="view"/>
+        <xsl:choose>
+            <xsl:when test="$view = 'diplomatic' or $view = 'commentary' or $view = 'reading'">
+                <p><xsl:apply-templates/></p>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:apply-templates/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+    <xsl:template match="tei:l">
         <xsl:param name="view"/>
         <xsl:choose>
             <xsl:when test="$view = 'diplomatic' or $view = 'commentary' or $view = 'reading'">


### PR DESCRIPTION
Meine Vorschläge für templates für XML `<l>` (für Verszeilen) und XML `<space>` (für zusätzliche Leerzeichen in Typoskripten). Kannst du mir Feedback geben, ob der Code jeweils richtig ist? Könnte man für die Regeln, die für jede Ansicht gelten (betrifft templates zu `l` und `lg`), das `xsl:choose` auch einfach weglassen?